### PR TITLE
insert key_id in header and use it to decode

### DIFF
--- a/src/crypto/decipher_type.rs
+++ b/src/crypto/decipher_type.rs
@@ -1,5 +1,9 @@
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum DecipherType {
-    Encrypted { chunk_size: usize, key_id: u64, header_size: usize },
+    Encrypted {
+        chunk_size: usize,
+        key_id: u64,
+        header_size: usize,
+    },
     Plaintext,
 }

--- a/src/crypto/decipher_type.rs
+++ b/src/crypto/decipher_type.rs
@@ -1,5 +1,5 @@
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum DecipherType {
-    Encrypted { chunk_size: usize, key_id: u64 },
+    Encrypted { chunk_size: usize, key_id: u64, header_size: usize },
     Plaintext,
 }

--- a/src/crypto/decoder.rs
+++ b/src/crypto/decoder.rs
@@ -40,7 +40,7 @@ impl<E> Decoder<E> {
             Poll::Ready(None)
         } else {
             match self.decipher_type {
-                DecipherType::Encrypted { chunk_size, key_id } => {
+                DecipherType::Encrypted { chunk_size, key_id, .. } => {
                     self.decrypt(cx, &chunk_size, self.keyring.get_key_by_id(key_id))
                 }
 

--- a/src/crypto/decoder.rs
+++ b/src/crypto/decoder.rs
@@ -1,5 +1,5 @@
-use super::decipher_type::DecipherType;
 use super::super::keyring::Keyring;
+use super::decipher_type::DecipherType;
 use actix_web::web::{Bytes, BytesMut};
 use core::pin::Pin;
 use core::task::{Context, Poll};
@@ -44,9 +44,7 @@ impl<E> Decoder<E> {
                     self.decrypt(cx, &chunk_size, self.keyring.get_key_by_id(key_id))
                 }
 
-                DecipherType::Plaintext => {
-                    Poll::Ready(Some(Ok(self.buffer.split().freeze())))
-                }
+                DecipherType::Plaintext => Poll::Ready(Some(Ok(self.buffer.split().freeze()))),
             }
         }
     }

--- a/src/crypto/decoder.rs
+++ b/src/crypto/decoder.rs
@@ -40,7 +40,9 @@ impl<E> Decoder<E> {
             Poll::Ready(None)
         } else {
             match self.decipher_type {
-                DecipherType::Encrypted { chunk_size, key_id, .. } => {
+                DecipherType::Encrypted {
+                    chunk_size, key_id, ..
+                } => {
                     if let Some(key) = self.keyring.get_key_by_id(&key_id) {
                         self.decrypt(cx, &chunk_size, key)
                     } else {

--- a/src/crypto/decoder.rs
+++ b/src/crypto/decoder.rs
@@ -41,7 +41,11 @@ impl<E> Decoder<E> {
         } else {
             match self.decipher_type {
                 DecipherType::Encrypted { chunk_size, key_id, .. } => {
-                    self.decrypt(cx, &chunk_size, self.keyring.get_key_by_id(key_id))
+                    if let Some(key) = self.keyring.get_key_by_id(&key_id) {
+                        self.decrypt(cx, &chunk_size, key)
+                    } else {
+                        panic!("Key {} not found !", key_id)
+                    }
                 }
 
                 DecipherType::Plaintext => Poll::Ready(Some(Ok(self.buffer.split().freeze()))),

--- a/src/crypto/decoder.rs
+++ b/src/crypto/decoder.rs
@@ -19,20 +19,6 @@ pub struct Decoder<E> {
 }
 
 impl<E> Decoder<E> {
-    pub fn new(
-        keyring: Keyring,
-        s: Box<dyn Stream<Item = Result<Bytes, E>> + Unpin>,
-    ) -> Decoder<E> {
-        Decoder {
-            inner: s,
-            inner_ended: false,
-            decipher_type: None,
-            stream_decoder: None,
-            buffer: BytesMut::new(),
-            keyring,
-        }
-    }
-
     pub fn new_from_cypher_and_buffer(
         keyring: Keyring,
         s: Box<dyn Stream<Item = Result<Bytes, E>> + Unpin>,

--- a/src/crypto/encoder.rs
+++ b/src/crypto/encoder.rs
@@ -15,11 +15,13 @@ pub struct Encoder<E> {
     buffer: BytesMut,
     chunk_size: usize,
     key: Key,
+    key_id: u64,
 }
 
 impl<E> Encoder<E> {
     pub fn new(
         key: Key,
+        key_id: u64,
         chunk_size: usize,
         s: Box<dyn Stream<Item = Result<Bytes, E>> + Unpin>,
     ) -> Encoder<E> {
@@ -30,6 +32,7 @@ impl<E> Encoder<E> {
             buffer: BytesMut::with_capacity(chunk_size),
             chunk_size,
             key,
+            key_id,
         }
     }
 
@@ -53,7 +56,7 @@ impl<E> Encoder<E> {
                     let mut buf =
                         BytesMut::with_capacity(HEADER_SIZE + encryption_header_bytes.len());
 
-                    let ds_header = Header::new(self.chunk_size, 0);
+                    let ds_header = Header::new(self.chunk_size, self.key_id);
                     let ds_header_bytes: Vec<u8> = ds_header.into();
                     buf.extend(&ds_header_bytes[..]);
                     buf.extend(encryption_header_bytes);

--- a/src/crypto/encoder.rs
+++ b/src/crypto/encoder.rs
@@ -53,7 +53,7 @@ impl<E> Encoder<E> {
                     let mut buf =
                         BytesMut::with_capacity(HEADER_SIZE + encryption_header_bytes.len());
 
-                    let ds_header = Header::new(self.chunk_size);
+                    let ds_header = Header::new(self.chunk_size, 0);
                     let ds_header_bytes: Vec<u8> = ds_header.into();
                     buf.extend(&ds_header_bytes[..]);
                     buf.extend(encryption_header_bytes);

--- a/src/crypto/header.rs
+++ b/src/crypto/header.rs
@@ -3,10 +3,12 @@ use std::convert::TryInto;
 
 pub const PREFIX: &[u8] = b"J'apercus l'audacieux capitaine.";
 pub const PREFIX_SIZE: usize = 32;
-const VERSION_NB: usize = 1;
-const VERSION_NB_SIZE: usize = 8;
+const VERSION_NB: usize = 2;
+pub const VERSION_NB_SIZE: usize = 8;
 const CHUNK_SIZE_SIZE: usize = 8; //usize size
+const KEY_ID_SIZE: usize = 8; //u64 size
 pub const HEADER_SIZE: usize = PREFIX_SIZE + VERSION_NB_SIZE + CHUNK_SIZE_SIZE;
+pub const HEADER_V2_SIZE: usize = HEADER_SIZE + KEY_ID_SIZE;
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub struct Header {

--- a/src/crypto/header.rs
+++ b/src/crypto/header.rs
@@ -69,8 +69,9 @@ impl From<Header> for Vec<u8> {
     fn from(header: Header) -> Vec<u8> {
         [
             PREFIX,
-            &VERSION_NB.to_le_bytes(),
+            &2_usize.to_le_bytes(),
             &header.chunk_size.to_le_bytes(),
+            &header.key_id.to_le_bytes(),
         ]
         .concat()
     }

--- a/src/crypto/header.rs
+++ b/src/crypto/header.rs
@@ -16,11 +16,11 @@ pub struct Header {
 }
 
 impl Header {
-    pub fn new(chunk_size: usize) -> Header {
+    pub fn new(chunk_size: usize, key_id: u64) -> Header {
         Header {
             version: VERSION_NB,
             chunk_size,
-            key_id: 0,
+            key_id,
         }
     }
 }
@@ -59,7 +59,7 @@ impl TryFrom<&[u8]> for Header {
                 .unwrap(),
         );
 
-        Ok(Header::new(chunk_size))
+        Ok(Header::new(chunk_size, 0))
     }
 }
 
@@ -123,7 +123,7 @@ mod tests {
 
     #[test]
     fn test_serialize_deserialize() {
-        let header = Header::new(10);
+        let header = Header::new(10, 0);
         let header_bytes: Vec<u8> = header.into();
         let received_header = Header::try_from(&header_bytes[..]).unwrap();
 

--- a/src/crypto/header_decoder.rs
+++ b/src/crypto/header_decoder.rs
@@ -99,9 +99,9 @@ mod tests {
 
         let mut boxy: Box<dyn Stream<Item = Result<Bytes, _>> + Unpin> = Box::new(source_stream);
 
-        let result = futures::executor::block_on(HeaderDecoder::new(&mut boxy));
+        let (cypher_type, buff) = futures::executor::block_on(HeaderDecoder::new(&mut boxy));
 
-        assert_eq!(DecipherType::Plaintext, result.0);
-        assert_eq!(Some(BytesMut::from(clear)), result.1);
+        assert_eq!(DecipherType::Plaintext, cypher_type);
+        assert_eq!(Some(BytesMut::from(clear)), buff);
     }
 }

--- a/src/crypto/header_decoder.rs
+++ b/src/crypto/header_decoder.rs
@@ -49,6 +49,7 @@ impl<E> HeaderDecoder<'_, E> {
             return ParseHeaderResponse::DecipherType(DecipherType::Encrypted {
                 chunk_size,
                 key_id: 0,
+                header_size: header::HEADER_SIZE
             });
         } else if self.buffer.len() < header::HEADER_V2_SIZE {
             return ParseHeaderResponse::MissingBytes;
@@ -63,7 +64,7 @@ impl<E> HeaderDecoder<'_, E> {
         trace!("header version: {:?}, chunk_size: {:?}, key_id: {:?}", version, chunk_size, key_id);
 
         let _ = self.buffer.split_to(header::HEADER_V2_SIZE);
-        ParseHeaderResponse::DecipherType(DecipherType::Encrypted { chunk_size, key_id })
+        ParseHeaderResponse::DecipherType(DecipherType::Encrypted { chunk_size, key_id, header_size: header::HEADER_V2_SIZE })
     }
 }
 
@@ -147,7 +148,8 @@ mod tests {
         assert_eq!(
             ParseHeaderResponse::DecipherType(DecipherType::Encrypted {
                 chunk_size: 10,
-                key_id: 0
+                key_id: 0,
+                header_size: header::HEADER_SIZE
             }),
             decoder.parse_header()
         );
@@ -158,7 +160,8 @@ mod tests {
         assert_eq!(
             ParseHeaderResponse::DecipherType(DecipherType::Encrypted {
                 chunk_size: 13,
-                key_id: 15
+                key_id: 15,
+                header_size: header::HEADER_V2_SIZE
             }),
             decoder.parse_header()
         );

--- a/src/crypto/header_decoder.rs
+++ b/src/crypto/header_decoder.rs
@@ -6,20 +6,61 @@ use core::task::{Context, Poll};
 use futures_core::stream::Stream;
 use futures_core::Future;
 use log::{error, trace};
-use std::convert::TryFrom;
+use std::convert::TryInto;
 use std::fmt::Debug;
 
 pub struct HeaderDecoder<'a, E> {
-    inner: &'a mut Box<dyn Stream<Item = Result<Bytes, E>> + Unpin>,
+    inner: Option<&'a mut Box<dyn Stream<Item = Result<Bytes, E>> + Unpin>>,
     buffer: BytesMut,
 }
 
 impl<E> HeaderDecoder<'_, E> {
     pub fn new(s: &mut Box<dyn Stream<Item = Result<Bytes, E>> + Unpin>) -> HeaderDecoder<E> {
         HeaderDecoder {
-            inner: s,
+            inner: Some(s),
             buffer: BytesMut::new(),
         }
+    }
+
+    pub fn parse_header(&mut self) -> ParseHeaderResponse {
+        if self.buffer.len() < header::HEADER_SIZE {
+            return ParseHeaderResponse::MissingBytes;
+        }
+
+        if &self.buffer[..header::PREFIX_SIZE] != header::PREFIX {
+            return ParseHeaderResponse::DecipherType(DecipherType::Plaintext);
+        }
+
+        let version = usize::from_le_bytes(
+            self.buffer[header::PREFIX_SIZE..header::PREFIX_SIZE + header::VERSION_NB_SIZE]
+                .try_into()
+                .unwrap(),
+        );
+
+        let chunk_size = usize::from_le_bytes(
+            self.buffer[header::PREFIX_SIZE + header::VERSION_NB_SIZE..header::HEADER_SIZE]
+                .try_into()
+                .unwrap(),
+        );
+
+        if version == 1 {
+            let _ = self.buffer.split_to(header::HEADER_SIZE);
+            return ParseHeaderResponse::DecipherType(DecipherType::Encrypted {
+                chunk_size,
+                key_id: 0,
+            });
+        } else if self.buffer.len() < header::HEADER_V2_SIZE {
+            return ParseHeaderResponse::MissingBytes;
+        }
+
+        let key_id = u64::from_le_bytes(
+            self.buffer[header::HEADER_SIZE..header::HEADER_V2_SIZE]
+                .try_into()
+                .unwrap(),
+        );
+
+        let _ = self.buffer.split_to(header::HEADER_V2_SIZE);
+        ParseHeaderResponse::DecipherType(DecipherType::Encrypted { chunk_size, key_id })
     }
 }
 
@@ -32,7 +73,7 @@ where
     fn poll(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
         let decoder = self.get_mut();
 
-        match Pin::new(decoder.inner.as_mut()).poll_next(cx) {
+        match Pin::new((decoder.inner.as_mut()).unwrap()).poll_next(cx) {
             Poll::Pending => {
                 trace!("poll: not ready");
                 Poll::Pending
@@ -49,44 +90,84 @@ where
                 trace!("poll: bytes, + {:?}", bytes.len());
                 decoder.buffer.extend(bytes);
 
-                if header::HEADER_SIZE <= decoder.buffer.len() {
-                    trace!("enough byte to decide decypher type");
-
-                    match header::Header::try_from(&decoder.buffer[0..header::HEADER_SIZE]) {
-                        Ok(header) => {
-                            trace!("the file is encrypted !");
-                            let _ = decoder.buffer.split_to(header::HEADER_SIZE);
-                            trace!("header_size : {:?}", header::HEADER_SIZE);
-                            trace!("buffer size left : {:?}", decoder.buffer.len());
-                            Poll::Ready((
-                                DecipherType::Encrypted {
-                                    chunk_size: header.chunk_size,
-                                    key_id: 0,
-                                },
-                                Some(decoder.buffer.clone()),
-                            ))
-                        }
-                        Err(header::HeaderParsingError::WrongPrefix) => {
-                            trace!("the file is not encrypted !");
-                            Poll::Ready((DecipherType::Plaintext, Some(decoder.buffer.clone())))
-                        }
-                        e => {
-                            error!("{:?}", e);
-                            panic!()
-                        }
+                match decoder.parse_header() {
+                    ParseHeaderResponse::MissingBytes => {
+                        trace!("not enough byte to decide decypher type");
+                        Pin::new(decoder).poll(cx)
                     }
-                } else {
-                    trace!("not enough byte to decide decypher type");
-                    Pin::new(decoder).poll(cx)
+                    ParseHeaderResponse::DecipherType(d) => {
+                        Poll::Ready((d, Some(decoder.buffer.clone())))
+                    }
                 }
             }
         }
     }
 }
 
+#[derive(Debug, PartialEq, Eq)]
+pub enum ParseHeaderResponse {
+    DecipherType(DecipherType),
+    MissingBytes,
+}
+
 #[cfg(test)]
 mod tests {
+    use header::Header;
+
     use super::*;
+
+    #[test]
+    fn test_parse_header() {
+        let empty: [u8; 0] = [];
+        let mut decoder = build_decoder(&empty);
+
+        assert_eq!(ParseHeaderResponse::MissingBytes, decoder.parse_header());
+        assert_eq!(empty, decoder.buffer[..]);
+
+        let plain_text = [0u8; header::HEADER_SIZE];
+        let mut decoder = build_decoder(&plain_text);
+
+        assert_eq!(
+            ParseHeaderResponse::DecipherType(DecipherType::Plaintext),
+            decoder.parse_header()
+        );
+        assert_eq!(plain_text, decoder.buffer[..]);
+
+        let v1_header: Vec<u8> = [
+            header::PREFIX,
+            &1_usize.to_le_bytes(),
+            &10_usize.to_le_bytes(),
+        ]
+        .concat();
+        let mut decoder = build_decoder(&v1_header);
+
+        assert_eq!(
+            ParseHeaderResponse::DecipherType(DecipherType::Encrypted {
+                chunk_size: 10,
+                key_id: 0
+            }),
+            decoder.parse_header()
+        );
+        assert_eq!(empty, decoder.buffer[..]);
+
+        let header_bytes_2: Vec<u8> = Header::new(13, 15).into();
+        let mut decoder = build_decoder(&header_bytes_2);
+        assert_eq!(
+            ParseHeaderResponse::DecipherType(DecipherType::Encrypted {
+                chunk_size: 13,
+                key_id: 15
+            }),
+            decoder.parse_header()
+        );
+        assert_eq!(empty, decoder.buffer[..]);
+    }
+
+    fn build_decoder(slice: &[u8]) -> HeaderDecoder<'_, String> {
+        HeaderDecoder {
+            buffer: BytesMut::from(slice),
+            inner: None,
+        }
+    }
 
     #[test]
     fn header_decoder() {

--- a/src/crypto/header_decoder.rs
+++ b/src/crypto/header_decoder.rs
@@ -45,6 +45,7 @@ impl<E> HeaderDecoder<'_, E> {
 
         if version == 1 {
             let _ = self.buffer.split_to(header::HEADER_SIZE);
+            trace!("header version: {:?}, chunk_size: {:?}, key_id: {:?}", version, chunk_size, 0);
             return ParseHeaderResponse::DecipherType(DecipherType::Encrypted {
                 chunk_size,
                 key_id: 0,
@@ -58,6 +59,8 @@ impl<E> HeaderDecoder<'_, E> {
                 .try_into()
                 .unwrap(),
         );
+
+        trace!("header version: {:?}, chunk_size: {:?}, key_id: {:?}", version, chunk_size, key_id);
 
         let _ = self.buffer.split_to(header::HEADER_V2_SIZE);
         ParseHeaderResponse::DecipherType(DecipherType::Encrypted { chunk_size, key_id })

--- a/src/crypto/header_decoder.rs
+++ b/src/crypto/header_decoder.rs
@@ -45,11 +45,16 @@ impl<E> HeaderDecoder<'_, E> {
 
         if version == 1 {
             let _ = self.buffer.split_to(header::HEADER_SIZE);
-            trace!("header version: {:?}, chunk_size: {:?}, key_id: {:?}", version, chunk_size, 0);
+            trace!(
+                "header version: {:?}, chunk_size: {:?}, key_id: {:?}",
+                version,
+                chunk_size,
+                0
+            );
             return ParseHeaderResponse::DecipherType(DecipherType::Encrypted {
                 chunk_size,
                 key_id: 0,
-                header_size: header::HEADER_SIZE
+                header_size: header::HEADER_SIZE,
             });
         } else if self.buffer.len() < header::HEADER_V2_SIZE {
             return ParseHeaderResponse::MissingBytes;
@@ -61,10 +66,19 @@ impl<E> HeaderDecoder<'_, E> {
                 .unwrap(),
         );
 
-        trace!("header version: {:?}, chunk_size: {:?}, key_id: {:?}", version, chunk_size, key_id);
+        trace!(
+            "header version: {:?}, chunk_size: {:?}, key_id: {:?}",
+            version,
+            chunk_size,
+            key_id
+        );
 
         let _ = self.buffer.split_to(header::HEADER_V2_SIZE);
-        ParseHeaderResponse::DecipherType(DecipherType::Encrypted { chunk_size, key_id, header_size: header::HEADER_V2_SIZE })
+        ParseHeaderResponse::DecipherType(DecipherType::Encrypted {
+            chunk_size,
+            key_id,
+            header_size: header::HEADER_V2_SIZE,
+        })
     }
 }
 

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -22,9 +22,9 @@ pub fn encrypted_content_length(clear_length: usize, chunk_size: usize) -> usize
     let remainder = clear_length % chunk_size;
 
     if remainder == 0 {
-        HEADER_SIZE + HEADERBYTES + nb_chunk * (ABYTES + chunk_size)
+        HEADER_V2_SIZE + HEADERBYTES + nb_chunk * (ABYTES + chunk_size)
     } else {
-        HEADER_SIZE + HEADERBYTES + nb_chunk * (ABYTES + chunk_size) + ABYTES + remainder
+        HEADER_V2_SIZE + HEADERBYTES + nb_chunk * (ABYTES + chunk_size) + ABYTES + remainder
     }
 }
 
@@ -154,7 +154,7 @@ mod tests {
         let original_length = 32;
         let chunk_size = 16;
         let nb_chunk = 32 / 16;
-        let encrypted_length = HEADER_SIZE + HEADERBYTES + nb_chunk * (ABYTES + chunk_size);
+        let encrypted_length = HEADER_V2_SIZE + HEADERBYTES + nb_chunk * (ABYTES + chunk_size);
 
         assert_eq!(
             encrypted_length,
@@ -168,7 +168,7 @@ mod tests {
         let chunk_size = 16;
         let nb_chunk = 32 / 16;
         let encrypted_length =
-            HEADER_SIZE + HEADERBYTES + nb_chunk * (ABYTES + chunk_size) + (ABYTES + 1);
+            HEADER_V2_SIZE + HEADERBYTES + nb_chunk * (ABYTES + chunk_size) + (ABYTES + 1);
 
         assert_eq!(
             encrypted_length,
@@ -179,7 +179,7 @@ mod tests {
     #[test]
     fn test_encrypted_content_length_with_another_exemple() {
         let original_length = 5882;
-        let encrypted_length = 6345;
+        let encrypted_length = 6353;
         let chunk_size = 256;
 
         assert_eq!(

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -34,7 +34,7 @@ pub fn decrypted_content_length(encrypted_length: usize, decipher: DecipherType)
     }
 
     match decipher {
-        DecipherType::Encrypted { chunk_size, .. } => {
+        DecipherType::Encrypted { chunk_size, header_size, .. } => {
             // encrypted = header_ds + header_crypto + n ( abytes + chunk ) + a (abytes + remainder)
             // with remainder < chunk and a = 0 if remainder = 0, a = 1 otherwise
             //

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -44,14 +44,14 @@ pub fn decrypted_content_length(encrypted_length: usize, decipher: DecipherType)
             //    = integer_part ( n + a (abytes + remainder) / (abytes + chunk) )
             //    = n
 
-            let nb_chunk = (encrypted_length - HEADER_SIZE - HEADERBYTES) / (ABYTES + chunk_size);
+            let nb_chunk = (encrypted_length - header_size - HEADERBYTES) / (ABYTES + chunk_size);
             let remainder_exists =
-                (encrypted_length - HEADER_SIZE - HEADERBYTES) % (ABYTES + chunk_size) != 0;
+                (encrypted_length - header_size - HEADERBYTES) % (ABYTES + chunk_size) != 0;
 
             if remainder_exists {
-                encrypted_length - HEADER_SIZE - HEADERBYTES - (nb_chunk + 1) * ABYTES
+                encrypted_length - header_size - HEADERBYTES - (nb_chunk + 1) * ABYTES
             } else {
-                encrypted_length - HEADER_SIZE - HEADERBYTES - nb_chunk * ABYTES
+                encrypted_length - header_size - HEADERBYTES - nb_chunk * ABYTES
             }
         }
 
@@ -74,6 +74,7 @@ mod tests {
             DecipherType::Encrypted {
                 chunk_size,
                 key_id: 0,
+                header_size: header::HEADER_SIZE
             },
         );
 
@@ -92,6 +93,7 @@ mod tests {
             DecipherType::Encrypted {
                 chunk_size,
                 key_id: 0,
+                header_size: header::HEADER_SIZE
             },
         );
 
@@ -111,6 +113,7 @@ mod tests {
             DecipherType::Encrypted {
                 chunk_size,
                 key_id: 0,
+                header_size: header::HEADER_SIZE
             },
         );
 
@@ -127,6 +130,7 @@ mod tests {
             DecipherType::Encrypted {
                 chunk_size: 256,
                 key_id: 0,
+                header_size: header::HEADER_SIZE
             },
         );
 

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -34,7 +34,11 @@ pub fn decrypted_content_length(encrypted_length: usize, decipher: DecipherType)
     }
 
     match decipher {
-        DecipherType::Encrypted { chunk_size, header_size, .. } => {
+        DecipherType::Encrypted {
+            chunk_size,
+            header_size,
+            ..
+        } => {
             // encrypted = header_ds + header_crypto + n ( abytes + chunk ) + a (abytes + remainder)
             // with remainder < chunk and a = 0 if remainder = 0, a = 1 otherwise
             //
@@ -74,7 +78,7 @@ mod tests {
             DecipherType::Encrypted {
                 chunk_size,
                 key_id: 0,
-                header_size: header::HEADER_SIZE
+                header_size: header::HEADER_SIZE,
             },
         );
 
@@ -93,7 +97,7 @@ mod tests {
             DecipherType::Encrypted {
                 chunk_size,
                 key_id: 0,
-                header_size: header::HEADER_SIZE
+                header_size: header::HEADER_SIZE,
             },
         );
 
@@ -113,7 +117,7 @@ mod tests {
             DecipherType::Encrypted {
                 chunk_size,
                 key_id: 0,
-                header_size: header::HEADER_SIZE
+                header_size: header::HEADER_SIZE,
             },
         );
 
@@ -130,7 +134,7 @@ mod tests {
             DecipherType::Encrypted {
                 chunk_size: 256,
                 key_id: 0,
-                header_size: header::HEADER_SIZE
+                header_size: header::HEADER_SIZE,
             },
         );
 

--- a/src/file.rs
+++ b/src/file.rs
@@ -11,12 +11,12 @@ pub fn encrypt(config: EncryptConfig) {
     let source: Result<Bytes, Error> = Ok(Bytes::from(input));
     let source_stream = futures::stream::once(Box::pin(async { source }));
 
-    let key = config
+    let (key_id, key) = config
         .keyring
         .get_last_key()
         .expect("no key avalaible for encryption");
 
-    let encoder = Encoder::new(key, config.chunk_size, Box::new(source_stream));
+    let encoder = Encoder::new(key, key_id, config.chunk_size, Box::new(source_stream));
 
     let buf = block_on_stream(encoder).map(|r| r.unwrap()).fold(
         BytesMut::with_capacity(64),

--- a/src/file.rs
+++ b/src/file.rs
@@ -11,7 +11,10 @@ pub fn encrypt(config: EncryptConfig) {
     let source: Result<Bytes, Error> = Ok(Bytes::from(input));
     let source_stream = futures::stream::once(Box::pin(async { source }));
 
-    let key = config.keyring.get_last_key();
+    let key = config
+        .keyring
+        .get_last_key()
+        .expect("no key avalaible for encryption");
 
     let encoder = Encoder::new(key, config.chunk_size, Box::new(source_stream));
 

--- a/src/http/handlers/encrypt_to_file.rs
+++ b/src/http/handlers/encrypt_to_file.rs
@@ -9,9 +9,9 @@ pub async fn encrypt_to_file(
 ) -> HttpResponse {
     let filepath = config.local_encryption_path_for(&req);
 
-    let key = config.keyring.get_last_key().expect("no key avalaible for encryption");
+    let (id, key) = config.keyring.get_last_key().expect("no key avalaible for encryption");
 
-    let mut encrypted_stream = Encoder::new(key, config.chunk_size, Box::new(payload));
+    let mut encrypted_stream = Encoder::new(key, id, config.chunk_size, Box::new(payload));
 
     // File::create is blocking operation, use threadpool
     let mut f = web::block(move || File::create(filepath))

--- a/src/http/handlers/encrypt_to_file.rs
+++ b/src/http/handlers/encrypt_to_file.rs
@@ -9,7 +9,10 @@ pub async fn encrypt_to_file(
 ) -> HttpResponse {
     let filepath = config.local_encryption_path_for(&req);
 
-    let (id, key) = config.keyring.get_last_key().expect("no key avalaible for encryption");
+    let (id, key) = config
+        .keyring
+        .get_last_key()
+        .expect("no key avalaible for encryption");
 
     let mut encrypted_stream = Encoder::new(key, id, config.chunk_size, Box::new(payload));
 

--- a/src/http/handlers/encrypt_to_file.rs
+++ b/src/http/handlers/encrypt_to_file.rs
@@ -9,7 +9,7 @@ pub async fn encrypt_to_file(
 ) -> HttpResponse {
     let filepath = config.local_encryption_path_for(&req);
 
-    let key = config.keyring.get_last_key();
+    let key = config.keyring.get_last_key().expect("no key avalaible for encryption");
 
     let mut encrypted_stream = Encoder::new(key, config.chunk_size, Box::new(payload));
 

--- a/src/http/handlers/forward.rs
+++ b/src/http/handlers/forward.rs
@@ -50,9 +50,17 @@ pub async fn forward(
     let stream: Box<dyn Stream<Item = _> + Unpin> = if config.noop {
         Box::new(payload)
     } else {
-        let (key_id, key) = config.keyring.get_last_key().expect("no key avalaible for encryption");
+        let (key_id, key) = config
+            .keyring
+            .get_last_key()
+            .expect("no key avalaible for encryption");
 
-        Box::new(Encoder::new(key, key_id, config.chunk_size, Box::new(payload)))
+        Box::new(Encoder::new(
+            key,
+            key_id,
+            config.chunk_size,
+            Box::new(payload),
+        ))
     };
 
     let req_copy = req.clone();

--- a/src/http/handlers/forward.rs
+++ b/src/http/handlers/forward.rs
@@ -50,9 +50,9 @@ pub async fn forward(
     let stream: Box<dyn Stream<Item = _> + Unpin> = if config.noop {
         Box::new(payload)
     } else {
-        let key = config.keyring.get_last_key().expect("no key avalaible for encryption");
+        let (key_id, key) = config.keyring.get_last_key().expect("no key avalaible for encryption");
 
-        Box::new(Encoder::new(key, config.chunk_size, Box::new(payload)))
+        Box::new(Encoder::new(key, key_id, config.chunk_size, Box::new(payload)))
     };
 
     let req_copy = req.clone();

--- a/src/http/handlers/forward.rs
+++ b/src/http/handlers/forward.rs
@@ -50,7 +50,7 @@ pub async fn forward(
     let stream: Box<dyn Stream<Item = _> + Unpin> = if config.noop {
         Box::new(payload)
     } else {
-        let key = config.keyring.get_last_key();
+        let key = config.keyring.get_last_key().expect("no key avalaible for encryption");
 
         Box::new(Encoder::new(key, config.chunk_size, Box::new(payload)))
     };

--- a/src/keyring.rs
+++ b/src/keyring.rs
@@ -11,11 +11,15 @@ impl Keyring {
         Keyring { keys }
     }
 
-    pub fn get_last_key(&self) -> Key {
-        self.keys.get(&0).unwrap().to_owned()
+    pub fn get_last_key(&self) -> Option<Key> {
+        if let Some(id) = self.keys.keys().max() {
+            self.get_key_by_id(id)
+        } else {
+            None
+        }
     }
 
-    pub fn get_key_by_id(&self, _id: u64) -> Key {
-        self.get_last_key()
+    pub fn get_key_by_id(&self, id: &u64) -> Option<Key> {
+        self.keys.get(id).map(|k| k.to_owned())
     }
 }

--- a/src/keyring.rs
+++ b/src/keyring.rs
@@ -1,3 +1,4 @@
+use log::trace;
 use sodiumoxide::crypto::secretstream::xchacha20poly1305::Key;
 use std::collections::HashMap;
 
@@ -11,9 +12,10 @@ impl Keyring {
         Keyring { keys }
     }
 
-    pub fn get_last_key(&self) -> Option<Key> {
+    pub fn get_last_key(&self) -> Option<(u64, Key)> {
         if let Some(id) = self.keys.keys().max() {
-            self.get_key_by_id(id)
+            trace!("returning key_id {} as last_key", id);
+            self.get_key_by_id(id).map(|k| (*id, k))
         } else {
             None
         }

--- a/src/keyring_utils.rs
+++ b/src/keyring_utils.rs
@@ -89,6 +89,38 @@ pub fn bootstrap_and_save_keyring(keyring_file: &str, master_password: String, s
     save_secrets(keyring_file, &secrets);
 }
 
+pub fn encrypt_and_save_keyring(
+    keys: Vec<[u8; 32]>,
+    keyring_path: &str,
+    master_password: String,
+    salt: String,
+) {
+
+    let mut key = [0u8; KEYBYTES];
+
+    let typed_salt = Salt::from_slice(salt.as_bytes()).unwrap();
+
+    pwhash::derive_key(
+        &mut key,
+        master_password.as_bytes(),
+        &typed_salt,
+        pwhash::OPSLIMIT_INTERACTIVE,
+        pwhash::MEMLIMIT_INTERACTIVE,
+    )
+    .unwrap();
+
+    let master_key = secretbox::Key::from_slice(&key.clone()).unwrap();
+
+    let hash = keys
+        .iter()
+        .enumerate()
+        .map(|(id, key)| (id.to_string(), base64_cipher(&master_key, *key)))
+        .collect();
+
+    let secrets = Secrets { cipher_keyring: hash };
+    save_secrets(keyring_path, &secrets);
+}
+
 fn base64_cipher(master_key: &secretbox::Key, key: [u8; 32]) -> String {
     let (cipher, nonce) = encrypt(master_key, key);
     let nonce_cipher = concat(nonce, cipher);

--- a/src/keyring_utils.rs
+++ b/src/keyring_utils.rs
@@ -95,7 +95,6 @@ pub fn encrypt_and_save_keyring(
     master_password: String,
     salt: String,
 ) {
-
     let mut key = [0u8; KEYBYTES];
 
     let typed_salt = Salt::from_slice(salt.as_bytes()).unwrap();
@@ -117,7 +116,9 @@ pub fn encrypt_and_save_keyring(
         .map(|(id, key)| (id.to_string(), base64_cipher(&master_key, *key)))
         .collect();
 
-    let secrets = Secrets { cipher_keyring: hash };
+    let secrets = Secrets {
+        cipher_keyring: hash,
+    };
     save_secrets(keyring_path, &secrets);
 }
 

--- a/tests/concurrent_uploads.rs
+++ b/tests/concurrent_uploads.rs
@@ -28,7 +28,7 @@ fn concurent_uploads() {
     const SERVER_LATENCY: Duration = Duration::from_millis(100);
 
     let _proxy_and_node =
-        ProxyAndNode::start_with_options(Some(SERVER_LATENCY), PrintServerLogs::No);
+        ProxyAndNode::start_with_options(Some(SERVER_LATENCY), PrintServerLogs::No, None);
 
     // Spawn threads (with a slight delay between each)
     let mut child_threads = vec![];

--- a/tests/content_length_and_transfert_encoding.rs
+++ b/tests/content_length_and_transfert_encoding.rs
@@ -19,7 +19,7 @@ async fn content_length_and_transfert_encoding() {
     let original_length = nb_chunk * CHUNK_SIZE;
     let content = vec![0; original_length];
 
-    let expected_encrypted_length = HEADER_SIZE + HEADERBYTES + nb_chunk * (ABYTES + CHUNK_SIZE);
+    let expected_encrypted_length = HEADER_V2_SIZE + HEADERBYTES + nb_chunk * (ABYTES + CHUNK_SIZE);
 
     let (uploaded_length, downloaded_length) =
         uploaded_and_downloaded_content_length(&content).await;
@@ -33,7 +33,7 @@ async fn content_length_and_transfert_encoding() {
     let content = vec![0; original_length];
 
     let expected_encrypted_length =
-        HEADER_SIZE + HEADERBYTES + nb_chunk * (ABYTES + CHUNK_SIZE) + ABYTES + 1;
+        HEADER_V2_SIZE + HEADERBYTES + nb_chunk * (ABYTES + CHUNK_SIZE) + ABYTES + 1;
 
     let (uploaded_length, downloaded_length) =
         uploaded_and_downloaded_content_length(&content).await;

--- a/tests/encryption_tests.rs
+++ b/tests/encryption_tests.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 
 use actix_web::web::{BufMut, Bytes, BytesMut};
 use actix_web::Error;
-use futures::executor::block_on_stream;
+use futures::executor::{block_on, block_on_stream};
 
 use proptest::prelude::*;
 
@@ -32,7 +32,14 @@ fn encoding_then_decoding_returns_source_data() {
         let source_stream  = futures::stream::once(Box::pin(async { source }));
 
         let encoder = Encoder::new(keyring.get_last_key(), chunk_size, Box::new(source_stream));
-        let decoder = Decoder::new(keyring.clone(), Box::new(encoder));
+
+        let mut boxy: Box<dyn futures::Stream<Item = Result<Bytes, _>> + Unpin> = Box::new(encoder);
+
+        let header_decoder = HeaderDecoder::new(&mut boxy);
+        let (cypher_type, buff) = block_on(header_decoder);
+
+        let decoder =
+        Decoder::new_from_cypher_and_buffer(keyring.clone(), boxy, cypher_type, buff);
 
         let buf = block_on_stream(decoder)
             .map(|r| r.unwrap())
@@ -50,7 +57,13 @@ fn decrypting_plaintext_returns_plaintext() {
         let source : Result<Bytes, Error> = Ok(Bytes::from(clear.clone()));
         let source_stream  = futures::stream::once(Box::pin(async { source }));
 
-        let decoder = Decoder::new(keyring.clone(), Box::new(source_stream));
+        let mut boxy: Box<dyn futures::Stream<Item = Result<Bytes, _>> + Unpin> = Box::new(source_stream);
+
+        let header_decoder = HeaderDecoder::new(&mut boxy);
+        let (cypher_type, buff) = block_on(header_decoder);
+
+        let decoder =
+        Decoder::new_from_cypher_and_buffer(keyring.clone(), boxy, cypher_type, buff);
 
         let buf = block_on_stream(decoder)
             .map(|r| r.unwrap())

--- a/tests/encryption_tests.rs
+++ b/tests/encryption_tests.rs
@@ -31,7 +31,7 @@ fn encoding_then_decoding_returns_source_data() {
         let source : Result<Bytes, Error> = Ok(Bytes::from(source_bytes.clone()));
         let source_stream  = futures::stream::once(Box::pin(async { source }));
 
-        let encoder = Encoder::new(keyring.get_last_key(), chunk_size, Box::new(source_stream));
+        let encoder = Encoder::new(keyring.get_last_key().unwrap(), chunk_size, Box::new(source_stream));
 
         let mut boxy: Box<dyn futures::Stream<Item = Result<Bytes, _>> + Unpin> = Box::new(encoder);
 

--- a/tests/encryption_tests.rs
+++ b/tests/encryption_tests.rs
@@ -31,7 +31,9 @@ fn encoding_then_decoding_returns_source_data() {
         let source : Result<Bytes, Error> = Ok(Bytes::from(source_bytes.clone()));
         let source_stream  = futures::stream::once(Box::pin(async { source }));
 
-        let encoder = Encoder::new(keyring.get_last_key().unwrap(), chunk_size, Box::new(source_stream));
+        let (key_id, key) = keyring.get_last_key().unwrap();
+
+        let encoder = Encoder::new(key, key_id, chunk_size, Box::new(source_stream));
 
         let mut boxy: Box<dyn futures::Stream<Item = Result<Bytes, _>> + Unpin> = Box::new(encoder);
 

--- a/tests/file_operations.rs
+++ b/tests/file_operations.rs
@@ -17,6 +17,8 @@ fn encrypt_and_decrypt() {
     let encrypted_path = encrypted.path();
     let decrypted_path = decrypted.path();
 
+    bootstrap_keyring();
+
     let mut encrypt_cmd = Command::cargo_bin("ds_proxy").unwrap();
     encrypt_cmd
         .arg("encrypt")
@@ -53,6 +55,8 @@ fn decrypt_witness_file() {
 
     let decrypted = temp.child("computer.dec.svg");
     let decrypted_path = decrypted.path();
+
+    bootstrap_keyring();
 
     let mut decrypt_cmd = Command::cargo_bin("ds_proxy").unwrap();
     decrypt_cmd

--- a/tests/helpers/mod.rs
+++ b/tests/helpers/mod.rs
@@ -37,11 +37,15 @@ pub struct ProxyAndNode {
 
 impl ProxyAndNode {
     pub fn start() -> ProxyAndNode {
-        ProxyAndNode::start_with_options(None, PrintServerLogs::No)
+        ProxyAndNode::start_with_options(None, PrintServerLogs::No, None)
     }
 
-    pub fn start_with_options(latency: Option<Duration>, log: PrintServerLogs) -> ProxyAndNode {
-        let proxy = launch_proxy(log, None);
+    pub fn start_with_keyring_path(keyring_path: &str) -> ProxyAndNode {
+        ProxyAndNode::start_with_options(None, PrintServerLogs::No, Some(keyring_path))
+    }
+
+    pub fn start_with_options(latency: Option<Duration>, log: PrintServerLogs, keyring_path: Option<&str>) -> ProxyAndNode {
+        let proxy = launch_proxy(log, keyring_path);
         let node = launch_node_with_latency(latency, log);
         thread::sleep(time::Duration::from_secs(4));
         ProxyAndNode { proxy, node }

--- a/tests/helpers/mod.rs
+++ b/tests/helpers/mod.rs
@@ -37,6 +37,7 @@ pub struct ProxyAndNode {
 
 impl ProxyAndNode {
     pub fn start() -> ProxyAndNode {
+        bootstrap_keyring();
         ProxyAndNode::start_with_options(None, PrintServerLogs::No, None)
     }
 

--- a/tests/helpers/mod.rs
+++ b/tests/helpers/mod.rs
@@ -73,6 +73,7 @@ pub fn launch_proxy(log: PrintServerLogs, keyring_path: Option<&str>) -> ChildGu
     let keyring = if let Some(file) = keyring_path {
         file
     } else {
+        bootstrap_keyring();
         DS_KEYRING
     };
 

--- a/tests/helpers/mod.rs
+++ b/tests/helpers/mod.rs
@@ -51,7 +51,7 @@ impl ProxyAndNode {
 
 pub fn bootstrap_keyring() {
     let mut command = Command::cargo_bin("ds_proxy").unwrap();
-    let result = command
+    command
         .arg("bootstrap-keyring")
         .arg(HASH_FILE_ARG)
         .env("DS_KEYRING", DS_KEYRING)
@@ -59,8 +59,6 @@ pub fn bootstrap_keyring() {
         .env("DS_SALT", SALT)
         .output()
         .expect("failed to perform bootstrap");
-
-    println!("result: {:?}", result);
 }
 
 pub fn launch_proxy(log: PrintServerLogs) -> ChildGuard {

--- a/tests/helpers/mod.rs
+++ b/tests/helpers/mod.rs
@@ -45,7 +45,11 @@ impl ProxyAndNode {
         ProxyAndNode::start_with_options(None, PrintServerLogs::No, Some(keyring_path))
     }
 
-    pub fn start_with_options(latency: Option<Duration>, log: PrintServerLogs, keyring_path: Option<&str>) -> ProxyAndNode {
+    pub fn start_with_options(
+        latency: Option<Duration>,
+        log: PrintServerLogs,
+        keyring_path: Option<&str>,
+    ) -> ProxyAndNode {
         let proxy = launch_proxy(log, keyring_path);
         let node = launch_node_with_latency(latency, log);
         thread::sleep(time::Duration::from_secs(4));

--- a/tests/keyring.rs
+++ b/tests/keyring.rs
@@ -29,7 +29,7 @@ fn multiple_keys() {
         let keys = ids_keys
             .iter()
             .take(id_usize + 1)
-            .map(|(_, key)| key.clone())
+            .map(|(_, key)| *key)
             .collect();
 
         make_keyring(keyring_path, keys);
@@ -47,7 +47,7 @@ fn multiple_keys() {
 
     let final_keyring_file = temp.child("final_keyring");
     let final_keyring_path = final_keyring_file.path().to_str().unwrap();
-    let final_keys = ids_keys.iter().map(|(_, key)| key.clone()).collect();
+    let final_keys = ids_keys.iter().map(|(_, key)| *key).collect();
     make_keyring(final_keyring_path, final_keys);
 
     let _proxy_and_node = ProxyAndNode::start_with_keyring_path(final_keyring_path);

--- a/tests/keyring.rs
+++ b/tests/keyring.rs
@@ -1,0 +1,87 @@
+use std::convert::TryInto;
+
+use assert_fs::prelude::*;
+use ds_proxy::crypto::header;
+use serial_test::serial;
+
+mod helpers;
+pub use helpers::*;
+
+#[test]
+#[serial(servers)]
+fn multiple_keys() {
+    /* this tests encrypt 3 files with 3 differents keys
+     * ensure the right key_id is written in the file
+     * and then download and decrypt the differnts files
+     */
+
+    let temp = assert_fs::TempDir::new().unwrap();
+
+    let ids_keys: Vec<(u64, [u8; 32])> = (0..3).map(|id| (id, random_key())).collect();
+
+    for (id, _) in &ids_keys {
+        println!("trying with id: {}", id);
+        let keyring_file = temp.child(format!("keyring_{}", id));
+        let keyring_path = keyring_file.path().to_str().unwrap();
+
+        let id_usize: usize = *id as usize;
+
+        let keys = ids_keys
+            .iter()
+            .take(id_usize + 1)
+            .map(|(_, key)| key.clone())
+            .collect();
+
+        make_keyring(keyring_path, keys);
+
+        let upload_url = format!("localhost:4444/upstream/victory_{}", id);
+        let upload_path = format!("tests/fixtures/server-static/uploads/victory_{}", id);
+
+        ensure_is_absent(&upload_path);
+
+        let _proxy_and_node = ProxyAndNode::start_with_keyring_path(keyring_path);
+        curl_put(COMPUTER_SVG_PATH, &upload_url);
+
+        assert_eq!(&key_id(&upload_path), id);
+    }
+
+    let final_keyring_file = temp.child("final_keyring");
+    let final_keyring_path = final_keyring_file.path().to_str().unwrap();
+    let final_keys = ids_keys.iter().map(|(_, key)| key.clone()).collect();
+    make_keyring(final_keyring_path, final_keys);
+
+    let _proxy_and_node = ProxyAndNode::start_with_keyring_path(final_keyring_path);
+
+    for i in 0..3 {
+        let download_url = format!("localhost:4444/upstream/victory_{}", i);
+        let curl_download = curl_get(&download_url);
+        assert_eq!(curl_download.stdout, COMPUTER_SVG_BYTES);
+    }
+
+    temp.close().unwrap();
+}
+
+fn make_keyring(keyring_path: &str, keys: Vec<[u8; 32]>) {
+    ds_proxy::keyring_utils::encrypt_and_save_keyring(
+        keys,
+        keyring_path,
+        PASSWORD.to_string(),
+        SALT.to_string(),
+    )
+}
+
+fn key_id(uploaded_path: &str) -> u64 {
+    let uploaded_bytes = std::fs::read(uploaded_path).expect("uploaded should exist !");
+
+    u64::from_le_bytes(
+        uploaded_bytes[header::HEADER_SIZE..header::HEADER_V2_SIZE]
+            .try_into()
+            .unwrap(),
+    )
+}
+
+fn random_key() -> [u8; 32] {
+    sodiumoxide::randombytes::randombytes(32)
+        .try_into()
+        .unwrap()
+}

--- a/tests/ping.rs
+++ b/tests/ping.rs
@@ -16,7 +16,7 @@ fn ping() {
      - curl /ping and expect to fetch a 404 which should trigger a maintenance mode
        on a upper stream proxy
     */
-    let _proxy_server = launch_proxy(PrintServerLogs::No);
+    let _proxy_server = launch_proxy(PrintServerLogs::No, None);
     thread::sleep(time::Duration::from_secs(2));
 
     let maintenance_file_path = "maintenance";


### PR DESCRIPTION
- on prend la dernière clé disponible dans le porte clés, on l'utilise pour chiffrer le fichier et on ajoute l'id de la clé dans un nouveau header (v2)
- pour le déchiffrement, on lit d'abords le header pour retrouver l'identifiant de la clé, avec celle-ci on déchiffre le fichier
 - pour assurer la rétro compatibilité, les fichiers chiffrés avec l'ancien header utilise la clé numéro 0
 - un tests assure le bon fonctionnement du nouveau header avec de multiple clé
 - le test witness confirme le fonctionnement avec l'ancien header
 - le calcul des longueurs des fichiers chiffrés / déchiffrés a été mis à jour